### PR TITLE
Extended hosts and host metrics api methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,12 @@ perl:
   - "5.16"
   - "5.18"
   - "5.20"
+
+before_install:
+  - cpanm --notest Minilla Carton
+
+install:
+  - carton install
+
+script:
+  - carton exec -- minil test --all

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tatsuro Hisamori <myfinder@cpan.org>"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.5.0, CPAN::Meta::Converter version 2.150005",
+   "generated_by" : "Minilla/v3.0.1, CPAN::Meta::Converter version 2.150010",
    "license" : [
       "perl_5"
    ],
@@ -49,9 +49,11 @@
       },
       "test" : {
          "requires" : {
+            "Plack" : "1.0042",
             "Test::Double" : "0.05",
             "Test::Fatal" : "0.013",
-            "Test::More" : "0.98"
+            "Test::More" : "0.98",
+            "Test::TCP" : "2.17"
          }
       }
    },
@@ -72,5 +74,5 @@
       "Tatsuro Hisamori <medianetworks@gmail.com>",
       "papix <mail@papix.net>"
    ],
-   "x_serialization_backend" : "JSON::PP version 2.27203"
+   "x_serialization_backend" : "JSON::PP version 2.27400"
 }

--- a/META.json
+++ b/META.json
@@ -72,7 +72,8 @@
    "version" : "0.03",
    "x_contributors" : [
       "Tatsuro Hisamori <medianetworks@gmail.com>",
-      "papix <mail@papix.net>"
+      "papix <mail@papix.net>",
+      "yoheimuta <yoheimuta@gmail.com>"
    ],
    "x_serialization_backend" : "JSON::PP version 2.27400"
 }

--- a/cpanfile
+++ b/cpanfile
@@ -6,5 +6,7 @@ on 'test' => sub {
     requires 'Test::More', '0.98';
     requires 'Test::Double', '0.05';
     requires 'Test::Fatal', '0.013';
+    requires 'Test::TCP', '2.17';
+    requires 'Plack', '1.0042';
 };
 

--- a/cpanfile.snapshot
+++ b/cpanfile.snapshot
@@ -1,5 +1,25 @@
 # carton snapshot format: version 1.0
 DISTRIBUTIONS
+  Apache-LogFormat-Compiler-0.33
+    pathname: K/KA/KAZEBURO/Apache-LogFormat-Compiler-0.33.tar.gz
+    provides:
+      Apache::LogFormat::Compiler 0.33
+    requirements:
+      Module::Build 0.38
+      POSIX 0
+      POSIX::strftime::Compiler 0.30
+      Time::Local 0
+      perl 5.008001
+  Class-Inspector-1.28
+    pathname: A/AD/ADAMK/Class-Inspector-1.28.tar.gz
+    provides:
+      Class::Inspector 1.28
+      Class::Inspector::Functions 1.28
+    requirements:
+      ExtUtils::MakeMaker 6.59
+      File::Spec 0.80
+      Test::More 0.47
+      perl 5.006
   Class-Method-Modifiers-Fast-0.041
     pathname: K/KI/KITANO/Class-Method-Modifiers-Fast-0.041.tar.gz
     provides:
@@ -20,10 +40,19 @@ DISTRIBUTIONS
       Class::Method::Modifiers::Fast 0
       Data::Util 0.44
       Exporter 5.57
-      ExtUtils::MakeMaker 6.98
+      ExtUtils::MakeMaker 7.24
       Hash::FieldHash 0
       Test::LeakTrace 0.08
       Test::More 0.62
+  Cookie-Baker-0.07
+    pathname: K/KA/KAZEBURO/Cookie-Baker-0.07.tar.gz
+    provides:
+      Cookie::Baker 0.07
+    requirements:
+      Exporter 0
+      Module::Build 0.38
+      URI::Escape 0
+      perl 5.008001
   Data-Util-0.63
     pathname: G/GF/GFUJI/Data-Util-0.63.tar.gz
     provides:
@@ -40,6 +69,43 @@ DISTRIBUTIONS
       Test::More 0.62
       XSLoader 0.02
       perl 5.008001
+  Devel-StackTrace-2.01
+    pathname: D/DR/DROLSKY/Devel-StackTrace-2.01.tar.gz
+    provides:
+      Devel::StackTrace 2.01
+      Devel::StackTrace::Frame 2.01
+    requirements:
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      Scalar::Util 0
+      overload 0
+      perl 5.006
+      strict 0
+      warnings 0
+  Devel-StackTrace-AsHTML-0.15
+    pathname: M/MI/MIYAGAWA/Devel-StackTrace-AsHTML-0.15.tar.gz
+    provides:
+      Devel::StackTrace::AsHTML 0.15
+    requirements:
+      Devel::StackTrace 0
+      ExtUtils::MakeMaker 0
+  Encode-Locale-1.05
+    pathname: G/GA/GAAS/Encode-Locale-1.05.tar.gz
+    provides:
+      Encode::Locale 1.05
+    requirements:
+      Encode 2
+      Encode::Alias 0
+      ExtUtils::MakeMaker 0
+      perl 5.008
+  Exporter-Tiny-0.042
+    pathname: T/TO/TOBYINK/Exporter-Tiny-0.042.tar.gz
+    provides:
+      Exporter::Shiny 0.042
+      Exporter::Tiny 0.042
+    requirements:
+      ExtUtils::MakeMaker 6.17
+      perl 5.006001
   ExtUtils-Config-0.008
     pathname: L/LE/LEONT/ExtUtils-Config-0.008.tar.gz
     provides:
@@ -78,67 +144,116 @@ DISTRIBUTIONS
       File::Spec 0
       strict 0
       warnings 0
-  ExtUtils-MakeMaker-7.02
-    pathname: B/BI/BINGOS/ExtUtils-MakeMaker-7.02.tar.gz
+  File-ShareDir-1.102
+    pathname: R/RE/REHSACK/File-ShareDir-1.102.tar.gz
     provides:
-      DynaLoader 7.02
-      ExtUtils::Command::MM 7.02
-      ExtUtils::Liblist 7.02
-      ExtUtils::Liblist::Kid 7.02
-      ExtUtils::MM 7.02
-      ExtUtils::MM_AIX 7.02
-      ExtUtils::MM_Any 7.02
-      ExtUtils::MM_BeOS 7.02
-      ExtUtils::MM_Cygwin 7.02
-      ExtUtils::MM_DOS 7.02
-      ExtUtils::MM_Darwin 7.02
-      ExtUtils::MM_MacOS 7.02
-      ExtUtils::MM_NW5 7.02
-      ExtUtils::MM_OS2 7.02
-      ExtUtils::MM_QNX 7.02
-      ExtUtils::MM_UWIN 7.02
-      ExtUtils::MM_Unix 7.02
-      ExtUtils::MM_VMS 7.02
-      ExtUtils::MM_VOS 7.02
-      ExtUtils::MM_Win32 7.02
-      ExtUtils::MM_Win95 7.02
-      ExtUtils::MY 7.02
-      ExtUtils::MakeMaker 7.02
-      ExtUtils::MakeMaker::Config 7.02
-      ExtUtils::MakeMaker::Locale 7.02
-      ExtUtils::MakeMaker::_version 7.02
-      ExtUtils::MakeMaker::charstar 7.02
-      ExtUtils::MakeMaker::version 7.02
-      ExtUtils::MakeMaker::version::regex 7.02
-      ExtUtils::MakeMaker::version::vpp 7.02
-      ExtUtils::Mkbootstrap 7.02
-      ExtUtils::Mksymlists 7.02
-      ExtUtils::testlib 7.02
-      MM 7.02
-      MY 7.02
-      in 7.02
-    requirements:
-      Data::Dumper 0
-      DirHandle 0
-      Encode 0
-      File::Basename 0
-      File::Spec 0.8
-      Pod::Man 0
-      perl 5.006
-  HTTP-Tiny-0.050
-    pathname: D/DA/DAGOLDEN/HTTP-Tiny-0.050.tar.gz
-    provides:
-      HTTP::Tiny 0.050
+      File::ShareDir 1.102
     requirements:
       Carp 0
-      ExtUtils::MakeMaker 6.17
-      Fcntl 0
-      IO::Socket 0
-      MIME::Base64 0
-      Time::Local 0
-      bytes 0
+      Class::Inspector 1.12
+      ExtUtils::MakeMaker 0
+      File::ShareDir::Install 0.03
+      File::Spec 0.80
+      perl 5.008001
+      warnings 0
+  File-ShareDir-Install-0.11
+    pathname: E/ET/ETHER/File-ShareDir-Install-0.11.tar.gz
+    provides:
+      File::ShareDir::Install 0.11
+    requirements:
+      Carp 0
+      Exporter 0
+      File::Spec 0
+      IO::Dir 0
+      Module::Build::Tiny 0.034
+      perl 5.008
       strict 0
       warnings 0
+  Filesys-Notify-Simple-0.12
+    pathname: M/MI/MIYAGAWA/Filesys-Notify-Simple-0.12.tar.gz
+    provides:
+      Filesys::Notify::Simple 0.12
+    requirements:
+      ExtUtils::MakeMaker 6.30
+  HTTP-Date-6.02
+    pathname: G/GA/GAAS/HTTP-Date-6.02.tar.gz
+    provides:
+      HTTP::Date 6.02
+    requirements:
+      ExtUtils::MakeMaker 0
+      Time::Local 0
+      perl 5.006002
+  HTTP-Entity-Parser-0.18
+    pathname: K/KA/KAZEBURO/HTTP-Entity-Parser-0.18.tar.gz
+    provides:
+      HTTP::Entity::Parser 0.18
+      HTTP::Entity::Parser::JSON undef
+      HTTP::Entity::Parser::MultiPart undef
+      HTTP::Entity::Parser::OctetStream undef
+      HTTP::Entity::Parser::UrlEncoded undef
+    requirements:
+      Encode 0
+      File::Temp 0
+      HTTP::MultiPartParser 0
+      Hash::MultiValue 0
+      JSON::MaybeXS 1.003007
+      Module::Build::Tiny 0.035
+      Module::Load 0
+      Stream::Buffered 0
+      WWW::Form::UrlEncoded 0.23
+      perl 5.008005
+  HTTP-Headers-Fast-0.20
+    pathname: T/TO/TOKUHIROM/HTTP-Headers-Fast-0.20.tar.gz
+    provides:
+      HTTP::Headers::Fast 0.20
+    requirements:
+      HTTP::Date 0
+      Module::Build 0.38
+      perl 5.008001
+  HTTP-Message-6.11
+    pathname: E/ET/ETHER/HTTP-Message-6.11.tar.gz
+    provides:
+      HTTP::Config 6.11
+      HTTP::Headers 6.11
+      HTTP::Headers::Auth 6.11
+      HTTP::Headers::ETag 6.11
+      HTTP::Headers::Util 6.11
+      HTTP::Message 6.11
+      HTTP::Request 6.11
+      HTTP::Request::Common 6.11
+      HTTP::Response 6.11
+      HTTP::Status 6.11
+    requirements:
+      Compress::Raw::Zlib 0
+      Encode 2.21
+      Encode::Locale 1
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      HTTP::Date 6
+      IO::Compress::Bzip2 2.021
+      IO::Compress::Deflate 0
+      IO::Compress::Gzip 0
+      IO::HTML 0
+      IO::Uncompress::Bunzip2 2.021
+      IO::Uncompress::Gunzip 0
+      IO::Uncompress::Inflate 0
+      IO::Uncompress::RawInflate 0
+      LWP::MediaTypes 6
+      MIME::Base64 2.1
+      MIME::QuotedPrint 0
+      URI 1.10
+      perl 5.008001
+  HTTP-MultiPartParser-0.01
+    pathname: C/CH/CHANSEN/HTTP-MultiPartParser-0.01.tar.gz
+    provides:
+      HTTP::MultiPartParser 0.01
+    requirements:
+      Carp 0
+      ExtUtils::MakeMaker 6.59
+      Scalar::Util 0
+      Test::Deep 0
+      Test::More 0.88
+      perl 5.008001
   Hash-FieldHash-0.14
     pathname: G/GF/GFUJI/Hash-FieldHash-0.14.tar.gz
     provides:
@@ -156,6 +271,13 @@ DISTRIBUTIONS
       XSLoader 0.02
       parent 0.221
       perl 5.008005
+  Hash-MultiValue-0.16
+    pathname: A/AR/ARISTOTLE/Hash-MultiValue-0.16.tar.gz
+    provides:
+      Hash::MultiValue 0.16
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.008001
   Hash-Util-FieldHash-Compat-0.08
     pathname: E/ET/ETHER/Hash-Util-FieldHash-Compat-0.08.tar.gz
     provides:
@@ -168,6 +290,15 @@ DISTRIBUTIONS
       parent 0
       strict 0
       warnings 0
+  IO-HTML-1.001
+    pathname: C/CJ/CJM/IO-HTML-1.001.tar.gz
+    provides:
+      IO::HTML 1.001
+    requirements:
+      Carp 0
+      Encode 2.10
+      Exporter 5.57
+      ExtUtils::MakeMaker 6.30
   JSON-2.90
     pathname: M/MA/MAKAMAKA/JSON-2.90.tar.gz
     provides:
@@ -177,15 +308,93 @@ DISTRIBUTIONS
     requirements:
       ExtUtils::MakeMaker 0
       Test::More 0
-  List-MoreUtils-0.33
-    pathname: A/AD/ADAMK/List-MoreUtils-0.33.tar.gz
+  JSON-MaybeXS-1.003008
+    pathname: E/ET/ETHER/JSON-MaybeXS-1.003008.tar.gz
     provides:
-      List::MoreUtils 0.33
+      JSON::MaybeXS 1.003008
     requirements:
+      Carp 0
       ExtUtils::CBuilder 0.27
-      ExtUtils::MakeMaker 6.52
-      Test::More 0.82
-      perl 5.00503
+      ExtUtils::MakeMaker 0
+      File::Spec 0
+      File::Temp 0
+      JSON::PP 2.27300
+      Scalar::Util 0
+      perl 5.006
+  LWP-MediaTypes-6.02
+    pathname: G/GA/GAAS/LWP-MediaTypes-6.02.tar.gz
+    provides:
+      LWP::MediaTypes 6.02
+    requirements:
+      ExtUtils::MakeMaker 0
+      perl 5.006002
+  List-MoreUtils-0.416
+    pathname: R/RE/REHSACK/List-MoreUtils-0.416.tar.gz
+    provides:
+      List::MoreUtils 0.416
+      List::MoreUtils::PP 0.416
+      List::MoreUtils::XS 0.416
+    requirements:
+      Carp 0
+      Exporter::Tiny 0.038
+      ExtUtils::MakeMaker 0
+      File::Basename 0
+      File::Copy 0
+      File::Path 0
+      File::Spec 0
+      IPC::Cmd 0
+      XSLoader 0.22
+      base 0
+  Module-Build-0.4220
+    pathname: L/LE/LEONT/Module-Build-0.4220.tar.gz
+    provides:
+      Module::Build 0.4220
+      Module::Build::Base 0.4220
+      Module::Build::Compat 0.4220
+      Module::Build::Config 0.4220
+      Module::Build::Cookbook 0.4220
+      Module::Build::Dumper 0.4220
+      Module::Build::Notes 0.4220
+      Module::Build::PPMMaker 0.4220
+      Module::Build::Platform::Default 0.4220
+      Module::Build::Platform::MacOS 0.4220
+      Module::Build::Platform::Unix 0.4220
+      Module::Build::Platform::VMS 0.4220
+      Module::Build::Platform::VOS 0.4220
+      Module::Build::Platform::Windows 0.4220
+      Module::Build::Platform::aix 0.4220
+      Module::Build::Platform::cygwin 0.4220
+      Module::Build::Platform::darwin 0.4220
+      Module::Build::Platform::os2 0.4220
+      Module::Build::PodParser 0.4220
+    requirements:
+      CPAN::Meta 2.142060
+      CPAN::Meta::YAML 0.003
+      Cwd 0
+      Data::Dumper 0
+      ExtUtils::CBuilder 0.27
+      ExtUtils::Install 0
+      ExtUtils::Manifest 0
+      ExtUtils::Mkbootstrap 0
+      ExtUtils::ParseXS 2.21
+      File::Basename 0
+      File::Compare 0
+      File::Copy 0
+      File::Find 0
+      File::Path 0
+      File::Spec 0.82
+      File::Temp 0.15
+      Getopt::Long 0
+      Module::Metadata 1.000002
+      Parse::CPAN::Meta 1.4401
+      Perl::OSType 1
+      Pod::Man 2.17
+      TAP::Harness 3.29
+      Test::More 0.49
+      Text::Abbrev 0
+      Text::ParseWords 0
+      perl 5.006001
+      version 0.87
   Module-Build-Tiny-0.039
     pathname: L/LE/LEONT/Module-Build-Tiny-0.039.tar.gz
     provides:
@@ -211,6 +420,116 @@ DISTRIBUTIONS
       perl 5.006
       strict 0
       warnings 0
+  POSIX-strftime-Compiler-0.42
+    pathname: K/KA/KAZEBURO/POSIX-strftime-Compiler-0.42.tar.gz
+    provides:
+      POSIX::strftime::Compiler 0.42
+    requirements:
+      Carp 0
+      Exporter 0
+      Module::Build 0.38
+      POSIX 0
+      Time::Local 0
+      perl 5.008001
+  Plack-1.0042
+    pathname: M/MI/MIYAGAWA/Plack-1.0042.tar.gz
+    provides:
+      HTTP::Message::PSGI undef
+      HTTP::Server::PSGI undef
+      Plack 1.0042
+      Plack::App::CGIBin undef
+      Plack::App::Cascade undef
+      Plack::App::Directory undef
+      Plack::App::File undef
+      Plack::App::PSGIBin undef
+      Plack::App::URLMap undef
+      Plack::App::WrapCGI undef
+      Plack::Builder undef
+      Plack::Component undef
+      Plack::HTTPParser undef
+      Plack::HTTPParser::PP undef
+      Plack::Handler undef
+      Plack::Handler::Apache1 undef
+      Plack::Handler::Apache2 undef
+      Plack::Handler::Apache2::Registry undef
+      Plack::Handler::CGI undef
+      Plack::Handler::CGI::Writer undef
+      Plack::Handler::FCGI undef
+      Plack::Handler::HTTP::Server::PSGI undef
+      Plack::Handler::Standalone undef
+      Plack::LWPish undef
+      Plack::Loader undef
+      Plack::Loader::Delayed undef
+      Plack::Loader::Restarter undef
+      Plack::Loader::Shotgun undef
+      Plack::MIME undef
+      Plack::Middleware undef
+      Plack::Middleware::AccessLog undef
+      Plack::Middleware::AccessLog::Timed undef
+      Plack::Middleware::Auth::Basic undef
+      Plack::Middleware::BufferedStreaming undef
+      Plack::Middleware::Chunked undef
+      Plack::Middleware::Conditional undef
+      Plack::Middleware::ConditionalGET undef
+      Plack::Middleware::ContentLength undef
+      Plack::Middleware::ContentMD5 undef
+      Plack::Middleware::ErrorDocument undef
+      Plack::Middleware::HTTPExceptions undef
+      Plack::Middleware::Head undef
+      Plack::Middleware::IIS6ScriptNameFix undef
+      Plack::Middleware::IIS7KeepAliveFix undef
+      Plack::Middleware::JSONP undef
+      Plack::Middleware::LighttpdScriptNameFix undef
+      Plack::Middleware::Lint undef
+      Plack::Middleware::Log4perl undef
+      Plack::Middleware::LogDispatch undef
+      Plack::Middleware::NullLogger undef
+      Plack::Middleware::RearrangeHeaders undef
+      Plack::Middleware::Recursive undef
+      Plack::Middleware::Refresh undef
+      Plack::Middleware::Runtime undef
+      Plack::Middleware::SimpleContentFilter undef
+      Plack::Middleware::SimpleLogger undef
+      Plack::Middleware::StackTrace undef
+      Plack::Middleware::Static undef
+      Plack::Middleware::XFramework undef
+      Plack::Middleware::XSendfile undef
+      Plack::Recursive::ForwardRequest undef
+      Plack::Request 1.0042
+      Plack::Request::Upload undef
+      Plack::Response 1.0042
+      Plack::Runner undef
+      Plack::TempBuffer undef
+      Plack::Test undef
+      Plack::Test::MockHTTP undef
+      Plack::Test::Server undef
+      Plack::Test::Suite undef
+      Plack::Util undef
+      Plack::Util::Accessor undef
+      Plack::Util::IOWithPath undef
+      Plack::Util::Prototype undef
+    requirements:
+      Apache::LogFormat::Compiler 0.33
+      Cookie::Baker 0.07
+      Devel::StackTrace 1.23
+      Devel::StackTrace::AsHTML 0.11
+      ExtUtils::MakeMaker 0
+      File::ShareDir 1.00
+      File::ShareDir::Install 0.06
+      Filesys::Notify::Simple 0
+      HTTP::Entity::Parser 0.17
+      HTTP::Headers::Fast 0.18
+      HTTP::Message 5.814
+      HTTP::Tiny 0.034
+      Hash::MultiValue 0.05
+      Pod::Usage 1.36
+      Stream::Buffered 0.02
+      Test::TCP 2.00
+      Try::Tiny 0
+      URI 1.59
+      WWW::Form::UrlEncoded 0.23
+      parent 0
+      perl 5.008001
   Scope-Guard-0.20
     pathname: C/CH/CHOCOLATE/Scope-Guard-0.20.tar.gz
     provides:
@@ -219,6 +538,16 @@ DISTRIBUTIONS
       ExtUtils::MakeMaker 0
       Test::More 0
       perl 5.006001
+  Stream-Buffered-0.03
+    pathname: D/DO/DOY/Stream-Buffered-0.03.tar.gz
+    provides:
+      Stream::Buffered 0.03
+      Stream::Buffered::Auto undef
+      Stream::Buffered::File undef
+      Stream::Buffered::PerlIO undef
+    requirements:
+      ExtUtils::MakeMaker 6.30
+      IO::File 1.14
   Sub-Uplevel-0.24
     pathname: D/DA/DAGOLDEN/Sub-Uplevel-0.24.tar.gz
     provides:
@@ -319,60 +648,18 @@ DISTRIBUTIONS
       Test::Harness 2.03
       Test::More 0.7
       Test::Simple 0.7
-  Test-Harness-3.34
-    pathname: L/LE/LEONT/Test-Harness-3.34.tar.gz
+  Test-Fatal-0.014
+    pathname: R/RJ/RJBS/Test-Fatal-0.014.tar.gz
     provides:
-      App::Prove 3.34
-      App::Prove::State 3.34
-      App::Prove::State::Result 3.34
-      App::Prove::State::Result::Test 3.34
-      Harness::Hook undef
-      TAP::Base 3.34
-      TAP::Formatter::Base 3.34
-      TAP::Formatter::Color 3.34
-      TAP::Formatter::Console 3.34
-      TAP::Formatter::Console::ParallelSession 3.34
-      TAP::Formatter::Console::Session 3.34
-      TAP::Formatter::File 3.34
-      TAP::Formatter::File::Session 3.34
-      TAP::Formatter::Session 3.34
-      TAP::Harness 3.34
-      TAP::Harness::Env 3.34
-      TAP::Object 3.34
-      TAP::Parser 3.34
-      TAP::Parser::Aggregator 3.34
-      TAP::Parser::Grammar 3.34
-      TAP::Parser::Iterator 3.34
-      TAP::Parser::Iterator::Array 3.34
-      TAP::Parser::Iterator::Process 3.34
-      TAP::Parser::Iterator::Stream 3.34
-      TAP::Parser::IteratorFactory 3.34
-      TAP::Parser::Multiplexer 3.34
-      TAP::Parser::Result 3.34
-      TAP::Parser::Result::Bailout 3.34
-      TAP::Parser::Result::Comment 3.34
-      TAP::Parser::Result::Plan 3.34
-      TAP::Parser::Result::Pragma 3.34
-      TAP::Parser::Result::Test 3.34
-      TAP::Parser::Result::Unknown 3.34
-      TAP::Parser::Result::Version 3.34
-      TAP::Parser::Result::YAML 3.34
-      TAP::Parser::ResultFactory 3.34
-      TAP::Parser::Scheduler 3.34
-      TAP::Parser::Scheduler::Job 3.34
-      TAP::Parser::Scheduler::Spinner 3.34
-      TAP::Parser::Source 3.34
-      TAP::Parser::SourceHandler 3.34
-      TAP::Parser::SourceHandler::Executable 3.34
-      TAP::Parser::SourceHandler::File 3.34
-      TAP::Parser::SourceHandler::Handle 3.34
-      TAP::Parser::SourceHandler::Perl 3.34
-      TAP::Parser::SourceHandler::RawTAP 3.34
-      TAP::Parser::YAMLish::Reader 3.34
-      TAP::Parser::YAMLish::Writer 3.34
-      Test::Harness 3.34
+      Test::Fatal 0.014
     requirements:
+      Carp 0
+      Exporter 5.57
       ExtUtils::MakeMaker 0
+      Test::Builder 0
+      Try::Tiny 0.07
+      strict 0
+      warnings 0
   Test-LeakTrace-0.14
     pathname: G/GF/GFUJI/Test-LeakTrace-0.14.tar.gz
     provides:
@@ -394,13 +681,123 @@ DISTRIBUTIONS
       Test::More 0.47
       Test::Tester 0.107
       perl 5.006
-  Test-Tester-0.109
-    pathname: F/FD/FDALY/Test-Tester-0.109.tar.gz
+  Test-SharedFork-0.35
+    pathname: E/EX/EXODIST/Test-SharedFork-0.35.tar.gz
     provides:
-      Test::Tester 0.109
-      Test::Tester::Capture undef
-      Test::Tester::CaptureRunner undef
-      Test::Tester::Delegate undef
+      Test::SharedFork 0.35
+      Test::SharedFork::Array undef
+      Test::SharedFork::Scalar undef
+      Test::SharedFork::Store undef
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      File::Temp 0
+      Test::Builder 0.32
+      Test::Builder::Module 0
+      Test::More 0.88
+      perl 5.008_001
+  Test-TCP-2.17
+    pathname: S/SY/SYOHEX/Test-TCP-2.17.tar.gz
+    provides:
+      Net::EmptyPort undef
+      Test::TCP 2.17
+      Test::TCP::CheckPort undef
+    requirements:
+      ExtUtils::MakeMaker 6.64
+      IO::Socket::INET 0
+      IO::Socket::IP 0
+      Test::More 0
+      Test::SharedFork 0.29
+      Time::HiRes 0
+      perl 5.008001
+  Try-Tiny-0.27
+    pathname: E/ET/ETHER/Try-Tiny-0.27.tar.gz
+    provides:
+      Try::Tiny 0.27
+    requirements:
+      Carp 0
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      constant 0
+      perl 5.006
+      strict 0
+      warnings 0
+  URI-1.71
+    pathname: E/ET/ETHER/URI-1.71.tar.gz
+    provides:
+      URI 1.71
+      URI::Escape 3.31
+      URI::Heuristic 4.20
+      URI::IRI 1.71
+      URI::QueryParam 1.71
+      URI::Split 1.71
+      URI::URL 5.04
+      URI::WithBase 2.20
+      URI::_foreign 1.71
+      URI::_generic 1.71
+      URI::_idna 1.71
+      URI::_ldap 1.71
+      URI::_login 1.71
+      URI::_punycode 1.71
+      URI::_query 1.71
+      URI::_segment 1.71
+      URI::_server 1.71
+      URI::_userpass 1.71
+      URI::data 1.71
+      URI::file 4.21
+      URI::file::Base 1.71
+      URI::file::FAT 1.71
+      URI::file::Mac 1.71
+      URI::file::OS2 1.71
+      URI::file::QNX 1.71
+      URI::file::Unix 1.71
+      URI::file::Win32 1.71
+      URI::ftp 1.71
+      URI::gopher 1.71
+      URI::http 1.71
+      URI::https 1.71
+      URI::ldap 1.71
+      URI::ldapi 1.71
+      URI::ldaps 1.71
+      URI::mailto 1.71
+      URI::mms 1.71
+      URI::news 1.71
+      URI::nntp 1.71
+      URI::pop 1.71
+      URI::rlogin 1.71
+      URI::rsync 1.71
+      URI::rtsp 1.71
+      URI::rtspu 1.71
+      URI::sftp 1.71
+      URI::sip 1.71
+      URI::sips 1.71
+      URI::snews 1.71
+      URI::ssh 1.71
+      URI::telnet 1.71
+      URI::tn3270 1.71
+      URI::urn 1.71
+      URI::urn::isbn undef
+      URI::urn::oid 1.71
+    requirements:
+      Exporter 5.57
+      ExtUtils::MakeMaker 0
+      MIME::Base64 2
+      Scalar::Util 0
+      parent 0
+      perl 5.008001
+      utf8 0
+  WWW-Form-UrlEncoded-0.23
+    pathname: K/KA/KAZEBURO/WWW-Form-UrlEncoded-0.23.tar.gz
+    provides:
+      WWW::Form::UrlEncoded 0.23
+      WWW::Form::UrlEncoded::PP undef
+    requirements:
+      Exporter 0
+      Module::Build 0.38
+      perl 5.008001
+  XSLoader-0.24
+    pathname: S/SA/SAPER/XSLoader-0.24.tar.gz
+    provides:
+      XSLoader 0.24
     requirements:
       ExtUtils::MakeMaker 0
-      Test::Builder 0
+      Test::More 0.47

--- a/lib/WebService/Mackerel.pm
+++ b/lib/WebService/Mackerel.pm
@@ -5,6 +5,7 @@ use warnings;
 use Carp qw/croak/;
 use JSON;
 use HTTP::Tiny;
+use URI;
 
 our $VERSION = "0.03";
 
@@ -123,9 +124,11 @@ sub get_latest_host_metrics {
 }
 
 sub get_hosts {
-    my ($self, $args) = @_;
-    my $path = '/api/v0/hosts.json';
-    my $res  = $self->{agent}->request('GET', $self->{mackerel_origin} . $path, {
+    my ($self, $query_parameters) = @_;
+    my $uri = URI->new($self->{mackerel_origin});
+    $uri->path('/api/v0/hosts.json');
+    $uri->query_form($query_parameters);
+    my $res = $self->{agent}->request('GET', $uri->as_string, {
             headers => {
                 'content-type' => 'application/json',
                 'X-Api-Key'    => $self->{api_key},

--- a/lib/WebService/Mackerel.pm
+++ b/lib/WebService/Mackerel.pm
@@ -111,6 +111,20 @@ sub post_host_metrics {
     return $res->{content};
 }
 
+sub get_host_metrics {
+    my ($self, $host_id, $query_parameters) = @_;
+    my $uri = URI->new($self->{mackerel_origin});
+    $uri->path("/api/v0/hosts/$host_id/metrics");
+    $uri->query_form($query_parameters);
+    my $res = $self->{agent}->request('GET', $uri->as_string, {
+            headers => {
+                'content-type' => 'application/json',
+                'X-Api-Key'    => $self->{api_key},
+            },
+        });
+    return $res->{content};
+}
+
 sub get_latest_host_metrics {
     my ($self, $args) = @_;
     my $path = '/api/v0/tsdb/latest?hostId=' . $args->{hostId} . '&name=' . $args->{name};

--- a/t/10_rail.t
+++ b/t/10_rail.t
@@ -157,26 +157,6 @@ subtest 'get_latest_host_metrics' => sub {
     Test::Double->reset;
 };
 
-subtest 'get_hosts' => sub {
-    my $fake_res = encode_json({
-        "hosts" => [ {
-            "createdAt" => 1416151310,
-            "id"        => "test_host_id",
-            "memo"      => "test memo",
-            "role"      => { [ "test-role" ] },
-        },]
-    });
-    my $mackerel = WebService::Mackerel->new( api_key  => 'testapikey', service_name => 'test' );
-    mock($mackerel)->expects('get_hosts')->times(1)->returns($fake_res);
-
-    my $res = $mackerel->get_hosts();
-
-    is_deeply $res, $fake_res, 'get_hosts : response success';
-
-    Test::Double->verify;
-    Test::Double->reset;
-};
-
 subtest 'create_monitor' => sub {
     my $fake_res = encode_json({
         "id"            => "test_monitor_id",

--- a/t/11_get_hosts.t
+++ b/t/11_get_hosts.t
@@ -1,0 +1,84 @@
+use strict;
+use Test::More;
+use Test::TCP qw(test_tcp);
+use Plack::Loader;
+use JSON qw/encode_json/;
+
+use WebService::Mackerel;
+
+my $endpoint = 'http://localhost';
+my $path     = '/api/v0/hosts.json';
+my $response_content = encode_json({
+    "hosts" => [ {
+        "createdAt" => 1416151310,
+        "id"        => "test_host_id",
+        "memo"      => "test memo",
+        "role"      => { [ "test-role" ] },
+    },]
+});
+
+subtest 'get_hosts' => sub {
+    my $params = { service => 'perl', role => 'app',
+        name => '10.0.1.10', status => 'working' };
+
+    test_tcp(
+        server => sub {
+            my $port = shift;
+            Plack::Loader->load('Standalone', port => $port)->run(
+                sub {
+                    my $env = shift;
+                    my $req_path = $env->{PATH_INFO};
+                    is $req_path, $path;
+
+                    my $query = $env->{QUERY_STRING};
+                    my %qparams = map { split '=', $_ } (split '&', $query);
+                    is_deeply \%qparams, $params;
+
+                    return [200, [], [$response_content]];
+                }
+            );
+        },
+        client => sub {
+            my ($port, $server_pid) = @_;
+            my $mackerel = WebService::Mackerel->new(
+                api_key  => 'testapikey',
+                service_name => 'test',
+                mackerel_origin => "$endpoint:$port",
+            );
+
+            my $res = $mackerel->get_hosts($params);
+            is_deeply $res, $response_content, 'get_hosts : response success';
+        },
+    );
+};
+
+subtest 'get_hosts with specifying multiple roles' => sub {
+    test_tcp(
+        server => sub {
+            my $port = shift;
+            Plack::Loader->load('Standalone', port => $port)->run(
+                sub {
+                    my $env = shift;
+                    my $req_url = $env->{REQUEST_URI};
+                    is $req_url, "$path?role=app&role=batch";
+
+                    return [200, [], [$response_content]];
+                }
+            );
+        },
+        client => sub {
+            my ($port, $server_pid) = @_;
+            my $mackerel = WebService::Mackerel->new(
+                api_key  => 'testapikey',
+                service_name => 'test',
+                mackerel_origin => "$endpoint:$port",
+            );
+
+            my @params = ( role => 'app', role => 'batch' );
+            my $res = $mackerel->get_hosts(\@params);
+            is_deeply $res, $response_content, 'get_hosts : response success';
+        },
+    );
+};
+
+done_testing;

--- a/t/12_get_host_metrics.t
+++ b/t/12_get_host_metrics.t
@@ -1,0 +1,54 @@
+use strict;
+use Test::More;
+use Test::TCP qw(test_tcp);
+use Plack::Loader;
+use JSON qw/encode_json/;
+
+use WebService::Mackerel;
+
+my $endpoint = 'http://localhost';
+my $host_id  = '2RnaLGypmBJ';
+my $path     = "/api/v0/hosts/$host_id/metrics";
+my $response_content = encode_json({
+    "metrics" => [{
+        "time" => 1478995200,"value" => 1.3820763888888887
+    },{
+        "time" => 1479081600,"value" => 1.4007222222222226
+    }]
+});
+
+subtest 'get_host_metrics' => sub {
+    my $params = { name => 'loadavg5', from => '1478744400', to => '1479303590' };
+
+    test_tcp(
+        server => sub {
+            my $port = shift;
+            Plack::Loader->load('Standalone', port => $port)->run(
+                sub {
+                    my $env = shift;
+                    my $req_path = $env->{PATH_INFO};
+                    is $req_path, $path;
+
+                    my $query = $env->{QUERY_STRING};
+                    my %qparams = map { split '=', $_ } (split '&', $query);
+                    is_deeply \%qparams, $params;
+
+                    return [200, [], [$response_content]];
+                }
+            );
+        },
+        client => sub {
+            my ($port, $server_pid) = @_;
+            my $mackerel = WebService::Mackerel->new(
+                api_key  => 'testapikey',
+                service_name => 'test',
+                mackerel_origin => "$endpoint:$port",
+            );
+
+            my $res = $mackerel->get_host_metrics($host_id, $params);
+            is_deeply $res, $response_content, 'get_host_metrics: response success';
+        },
+    );
+};
+
+done_testing;


### PR DESCRIPTION
I want to call [/api/v0/hosts.json](https://mackerel.io/ja/api-docs/entry/hosts#list) with any query parameters and [/api/v0/hosts/{host_id}/metrics](https://mackerel.io/ja/api-docs/entry/host-metrics#get).

Usage examples:

```perl
my @args = (service => "service", role => "bastion", 
    role => "batch", status => "working");
my $content = $mackerel->get_hosts(\@args);
```

```perl
my $host_id = "2RnaLGypmBJ"; 
my $args = { name => 'loadavg5', from => '1478744400', to => '1479303590' }; 
my $content = $mackerel->get_host_metrics($host_id, $args);
```